### PR TITLE
Data directory validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v4.0.0
-      with:
-        poetry-version: 2.1
+      run: |
+        pipx install poetry --python python${{ matrix.python-version }}
+        poetry --version
 
     - name: Install dependencies
       run: poetry install

--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ options:
                         Validate file locations
 ```
 
+### manifests
+
+This subcommand updates the manifest files within data directories.
+
+```txt
+ve_data_science_tool manifests -h
+usage: ve_data_science_tool manifests [-h] [directory]
+
+Update manifest files within data directories recursively within a directory. If a 
+directory is not provided then the default is to update manifests starting in the root 
+`data` directory. This command does not check manifest metadata - just updates the 
+manifests to ensure all files are included. It does not remove files from the manifest.
+
+positional arguments:
+  directory   Specific directory to update
+
+options:
+  -h, --help  show this help message and exit
+```
+
 ### data
 
 This subcommand checks that the data directories provide directory manifest metadata and

--- a/ve_data_science_tool/data.py
+++ b/ve_data_science_tool/data.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 from pprint import pformat
 from textwrap import indent
-from typing import Any, ClassVar
+from typing import ClassVar, Literal
 
 import yaml
-from marshmallow import Schema, validates_schema
+from marshmallow import Schema
 from marshmallow.exceptions import ValidationError
 from marshmallow_dataclass import dataclass
 from marshmallow_dataclass.typing import Url
@@ -24,12 +24,6 @@ class ManifestFile:
     script: str | None = None
     md5: str | None = None
 
-    @validates_schema
-    def validate_url_or_schema(self, data: dict, **kwargs: Any) -> None:
-        """Further validation of loaded data."""
-        if not ((data["url"] is None) ^ (data["script"] is None)):
-            raise ValidationError(f"{data['name']}: provide _one_ of url or script")
-
 
 @dataclass
 class Manifest:
@@ -40,6 +34,32 @@ class Manifest:
 
     # Type the Schema attribute
     Schema: ClassVar[type[Schema]]
+
+
+def load_manifest(file: Path) -> Manifest:
+    """Load a manifest file.
+
+    Args:
+        file: A Path to a manifest file.
+
+    Raises:
+        YAMLError: File contents not valid YAML.
+        ValidationError: File contents not congruent with Manifest schema.
+    """
+
+    with open(file) as manifest_io:
+        try:
+            manifest_data: dict = yaml.safe_load(manifest_io)
+        except yaml.error.YAMLError:
+            raise
+
+    # Does it conform to the Schema
+    try:
+        manifest = Manifest.Schema().load(data=manifest_data)
+    except ValidationError:
+        raise
+
+    return manifest
 
 
 def check_data_directory(config: Config, directory: Path) -> bool:
@@ -57,81 +77,110 @@ def check_data_directory(config: Config, directory: Path) -> bool:
         directory: A path to a data directory.
     """
 
-    LOGGER.info(f"Checking {directory}")
+    # Check that the directory a subpath within the repository
+    try:
+        directory_relative = directory.resolve().relative_to(config.repository_path)
+    except ValueError:
+        LOGGER.error(
+            f" \u2717 The directory is not within the "
+            f"ve_data_science repo: {directory!s}"
+        )
+        return False
+
+    LOGGER.info(f"Checking {directory_relative}")
 
     # Do we have a directory to validate
     if not directory.exists():
-        LOGGER.error(" - Directory not found")
+        LOGGER.error(" \u2717 Directory not found")
         return False
 
     if not directory.is_dir():
-        LOGGER.error(" - Directory path is a file not a directory")
+        LOGGER.error(" \u2717 Directory path is a file not a directory")
         return False
 
-    # Get the directory contents
+    # Get the directory file as a set
     actual_files = {
         f.name
         for f in directory.iterdir()
-        if not f.name.startswith(".") and f.is_file()
+        if not f.name.startswith(".") and f.is_file() and f.name != "MANIFEST.yaml"
     }
 
-    LOGGER.info(f" - Found {len(actual_files)} files.")
+    # Check the MANIFEST.yaml file is present if files are present and that no MANIFEST
+    # is found if there are no files
+    manifest_file = directory / "MANIFEST.yaml"
 
-    # Check the MANIFEST.yaml file is present and that it can be read
-    if "MANIFEST.yaml" not in actual_files:
-        LOGGER.error(" - MANIFEST.yaml not found")
+    if actual_files and not manifest_file.exists():
+        LOGGER.error(" \u2717 MANIFEST.yaml not found")
         return False
 
-    with open(directory / "MANIFEST.yaml") as manifest_io:
-        try:
-            manifest_data: dict = yaml.safe_load(manifest_io)
-        except yaml.error.YAMLError as excep:
-            LOGGER.error(" - Cannot parse MANIFEST.yaml")
-            LOGGER.error(excep)
-            return False
+    if not actual_files and manifest_file.exists():
+        LOGGER.error(" \u2717 MANIFEST.yaml file not required unless files are present")
+        return False
 
-    # Does it conform to the Schema
+    if not actual_files and not manifest_file.exists():
+        LOGGER.error(" \u2713 Directory empty: no manifest required.")
+        return True
+
+    # Load the manifest, logging errors.
     try:
-        manifest: Manifest = Manifest.Schema().load(data=manifest_data)
+        manifest = load_manifest(manifest_file)
+    except yaml.error.YAMLError as excep:
+        LOGGER.error(" \u2717 Cannot parse MANIFEST.yaml")
+        LOGGER.error(excep)
+        return False
     except ValidationError as excep:
-        LOGGER.error(" - MANIFEST.yaml structure incorrect:")
+        LOGGER.error(" \u2717 MANIFEST.yaml structure incorrect:")
         LOGGER.error(indent(pformat(excep.messages, indent=1, compact=True), "   "))
         return False
 
     # Are the contents valid and complete.
     # - These checks should all run before returning to give a complete assessment.
     return_value = True
+    logged_errors = []
 
     # Is the relative directory path in the manifest file congruent with its location?
-    manifest_path_parts = Path(manifest.directory).parts
-    location_path_parts = directory.parts[-len(manifest_path_parts) :]
-    if manifest_path_parts != location_path_parts:
-        LOGGER.error(
-            f" - MANIFEST.yaml directory name does not match: {manifest.directory}"
+    if directory_relative != Path(manifest.directory):
+        logged_errors.append(
+            f"   \u2717 MANIFEST.yaml directory name does not match "
+            f"location: {manifest.directory}"
         )
         return_value = False
 
-    # - Does the manifest list all of the files?
-    actual_files.remove("MANIFEST.yaml")
     manifest_files = {entry.name for entry in manifest.files}
 
     if not manifest_files == actual_files:
         only_in_manifest = manifest_files.difference(actual_files)
         only_in_directory = actual_files.difference(manifest_files)
 
-        LOGGER.error(" - MANIFEST.yaml files do not match directory contents:")
-
         if only_in_manifest:
-            LOGGER.error(f"   Only in manifest: {', '.join(only_in_manifest)}")
+            logged_errors.append(
+                f"   \u2717 Unknown files in manifest: {', '.join(only_in_manifest)}"
+            )
         if only_in_directory:
-            LOGGER.error(f"   Only in directory: {', '.join(only_in_directory)}")
+            logged_errors.append(
+                f"   \u2717 Files missing from manifest: {', '.join(only_in_directory)}"
+            )
 
         return_value = False
 
+    # Is the script or url attribute set for each file. Although this check could be in
+    # the dataclass schema using the @validates_schema decorator, we want to be able to
+    # read and write partially complete manifests, so it is only implemented as part of
+    # explicit metadata validation.
+
+    for file in manifest.files:
+        if not (file.url is None) ^ (file.script is None):
+            logged_errors.append(
+                f"   \u2717 File does not provide _one_ of url or script: {file.name}"
+            )
+            return_value = False
+
     if return_value is True:
-        LOGGER.info(" - Directory validated")
+        LOGGER.info(" \u2713 Valid manifest")
     else:
-        LOGGER.error(" - Directory manifest contains errors")
+        LOGGER.error(" \u2717 Manifest contains errors")
+        for msg in logged_errors:
+            LOGGER.error(msg)
 
     return return_value
 
@@ -162,4 +211,138 @@ def check_data(config: Config, directory: Path | None = None) -> bool:
     for each_dir in directories:
         check_data_directory(config=config, directory=each_dir)
 
+    return True
+
+
+def populate_manifest(
+    config: Config, directory: Path
+) -> tuple[Literal["empty", "created", "updated"], list[Path]]:
+    """Populates a manifest file in a directory.
+
+    If the directory does not contain a MANIFEST.yaml file, then one is created within
+    the directory and the ``files`` attribute is populated from the directory contents.
+    If the directory does contain a MANIFEST.yaml file, then it is opened and any new
+    files are added to the manifest. Hidden files are not included in manifest files.
+
+    This function does not do any metadata checking or population - it just creates
+    manifest entries for files within the directory. The resulting manifest files will
+    not pass data metadata validation and need further checking to do so. Critically:
+
+    * The url or script attributes for newly added files are not populated.
+    * The function does not remove manifest entries for files that are not present in
+      the directory. These files might be missing in the local directory or might
+      genuinely have been removed, but that is something to solve at the data
+      metadata validation step.
+
+    The function does not create a manifest in a directory that does not contain files.
+    The function returns a tuple containing the status of the population and a list of
+    the paths added to the manifest.
+
+    Args:
+        config: A config object
+        directory: A directory within which to carry out script validation.
+    """
+
+    # Check that the directory a subpath within the repository
+    try:
+        directory_relative = directory.resolve().relative_to(config.repository_path)
+    except ValueError:
+        raise ValueError(
+            f"The directory is not within the ve_data_science repo: {directory!s}"
+        )
+
+    # Get the expected manifest file path and the non-hidden files within the directory
+    # that are not the MANIFEST file itself (if one exists) paths in the directory
+    manifest_path = directory / "MANIFEST.yaml"
+    # TODO - filter to data files?
+    files = [
+        f
+        for f in directory.glob("*")
+        if not (f.is_dir() or f.name.startswith(".") or f.name == "MANIFEST.yaml")
+    ]
+
+    if not (manifest_path).exists():
+        # Do not create manifest files in empty directories
+        if not files:
+            return "empty", files
+
+        # If a manifest file does not exist then create one, using the existing files
+        # within the directory. This does not attempt to populate the url or script
+        # attribute.
+        manifest = Manifest(
+            directory=str(directory_relative),
+            files=[ManifestFile(name=f.name) for f in files],
+        )
+
+        with open(manifest_path, "w") as outfile:
+            yaml.safe_dump(data=Manifest.Schema().dump(manifest), stream=outfile)
+
+        return "created", files
+
+    # Otherwise, update the existing manifest with any new files
+    try:
+        manifest = load_manifest(manifest_path)
+    except (yaml.error.YAMLError, ValidationError):
+        raise
+
+    existing_files = set([f.name for f in manifest.files])
+    new_files = [f for f in files if f.name not in existing_files]
+    for file in new_files:
+        manifest.files.append(ManifestFile(name=file.name))
+
+    with open(manifest_path, "w") as outfile:
+        yaml.safe_dump(data=Manifest.Schema().dump(manifest), stream=outfile)
+
+    return "updated", list(new_files)
+
+
+def update_manifests(config: Config, directory: Path | None = None) -> bool:
+    """Recursively update data directory manifest files.
+
+    This function iterates recursively within a target directory, updating manifest
+    files. If no manifest file is found, one is created. Otherwise, files in each
+    directory are added to the existing manifest file.
+
+    Args:
+        config: A config object
+        directory: A directory within which to carry out script validation.
+
+    """
+
+    # Default is to search the data directory
+    if directory is None:
+        directory = Path(config.repository_path) / "data"
+
+    LOGGER.info(f"Checking all data directories within : {directory}")
+
+    # Walk the directories. Future note pathlib.Path.walk() in 3.12+
+    directories = [path for path in directory.rglob("*") if path.is_dir()]
+    directories.insert(0, directory)
+
+    for each_dir in directories:
+        directory_relative = each_dir.resolve().relative_to(config.repository_path)
+        LOGGER.info(f"  Directory: {directory_relative}")
+
+        try:
+            status, files = populate_manifest(config=config, directory=each_dir)
+        except yaml.error.YAMLError as excep:
+            LOGGER.error(f"   \u2717 Existing manifest not valid YAML: {excep!s}")
+            continue
+        except ValidationError as excep:
+            LOGGER.error("   \u2717 Existing manifest contains metadata errors:")
+            LOGGER.error(
+                indent(pformat(excep.messages, indent=1, compact=True), " " * 5)
+            )
+            continue
+
+        match status:
+            case "empty":
+                LOGGER.info("   \u2713 Empty directory")
+            case "created":
+                LOGGER.info(f"   \u2713 Manifest created: {len(files)} added")
+            case "updated":
+                if files:
+                    LOGGER.info(f"   \u2713 Manifest updated: {len(files)} added")
+                else:
+                    LOGGER.info("   \u2713 Manifest up to date")
     return True

--- a/ve_data_science_tool/data.py
+++ b/ve_data_science_tool/data.py
@@ -114,7 +114,7 @@ def check_data_directory(config: Config, directory: Path) -> bool:
         return False
 
     if not actual_files and manifest_file.exists():
-        LOGGER.error(" \u2717 MANIFEST.yaml file not required unless files are present")
+        LOGGER.error(" \u2717 MANIFEST.yaml file in empty directory")
         return False
 
     if not actual_files and not manifest_file.exists():
@@ -141,7 +141,7 @@ def check_data_directory(config: Config, directory: Path) -> bool:
     # Is the relative directory path in the manifest file congruent with its location?
     if directory_relative != Path(manifest.directory):
         logged_errors.append(
-            f"   \u2717 MANIFEST.yaml directory name does not match "
+            f"   \u2717 MANIFEST.yaml directory does not match "
             f"location: {manifest.directory}"
         )
         return_value = False

--- a/ve_data_science_tool/entry_points.py
+++ b/ve_data_science_tool/entry_points.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from ve_data_science_tool import LOGGER
 from ve_data_science_tool.config import configure, load_config
-from ve_data_science_tool.data import check_data
+from ve_data_science_tool.data import check_data, update_manifests
 from ve_data_science_tool.globus import globus_status, globus_sync
 from ve_data_science_tool.scripts import check_scripts
 
@@ -79,6 +79,20 @@ def ve_data_science_tool_cli(args_list: list[str] | None = None) -> int:
         "directory", type=Path, help="Specific directory to check", nargs="?"
     )
 
+    update_manifests_subparser = subparsers.add_parser(
+        "manifests",
+        description="""Update manifest files within data directories recursively within
+            a directory. If a directory is not provided then the default is to update
+            manifests starting in the root `data` directory. This command does not check
+            manifest metadata - just updates the manifests to ensure all files are
+            included. It does not remove files from the manifest.""",
+        help="Update data manifests",
+    )
+
+    update_manifests_subparser.add_argument(
+        "directory", type=Path, help="Specific directory to update", nargs="?"
+    )
+
     # TODO Currently no argument but probably will want them
     globus_sync_subparser = subparsers.add_parser(  # noqa: F841
         "globus_sync",
@@ -133,6 +147,8 @@ def ve_data_science_tool_cli(args_list: list[str] | None = None) -> int:
                 directory=args.directory,
                 check_file_locations=args.check_file_locations,
             )
+        case "manifests":
+            update_manifests(config=config, directory=args.directory)
         case "data":
             check_data(config=config, directory=args.directory)
         case "globus_sync":

--- a/ve_data_science_tool/globus.py
+++ b/ve_data_science_tool/globus.py
@@ -348,7 +348,7 @@ def globus_ls(
 def get_sync_status(
     transfer_client: globus_sdk.TransferClient,
     config: Config,
-    ls_filter: str = "name:!~.*",
+    ls_filter: str = "name:!~.*/name:!~MANIFEST.yaml",
 ) -> dict[str, list[str]]:
     """Generate a report on the synchronization of the remote and local endpoints.
 
@@ -362,11 +362,15 @@ def get_sync_status(
     * ``remote_outdated``:  present on both but the local file is newer
     * ``local_outdated``: present on both but the remote file is newer
 
+    The status check explicitly ignores hidden files and MANIFEST.yaml files. For
+    details of the filter string syntax, see:
+    https://docs.globus.org/api/transfer/file_operations/#dir_listing_filtering
+
     Args:
         transfer_client: An authenticated GLOBUS transfer client.
         config: A config object.
         ls_filter: Filters to pass on to the listing process. The default is to ignore
-            hidden files.
+            hidden files and MANIFEST.yaml files.
     """
 
     # Get the file listings for each endpoint

--- a/ve_data_science_tool/globus.py
+++ b/ve_data_science_tool/globus.py
@@ -87,14 +87,19 @@ def globus_transfer(
     source_path: str,
     destination_path: str,
     filters: tuple[
-        tuple[Literal["include", "exclude"], str, Literal["file", "dir"]]
-    ] = (("exclude", ".*", "file"),),
+        tuple[Literal["include", "exclude"], str, Literal["file", "dir"]], ...
+    ] = (
+        ("exclude", ".*", "file"),
+        ("exclude", "MANIFEST.yaml", "file"),
+    ),
 ) -> bool:
     """Synchronize files with GLOBUS.
 
     This function sets up and runs a transfer between two endpoints. See the SDK
     documentation at https://docs.globus.org/api/transfer/task/#task_document for
     information on the task info data that is being monitored.
+
+    By default, the transfer filters out MANIFEST.yaml files and hidden files.
 
     Args:
         transfer_client: An authenticated GLOBUS transfer client.

--- a/ve_data_science_tool/scripts.py
+++ b/ve_data_science_tool/scripts.py
@@ -327,7 +327,7 @@ def check_scripts(
                         LOGGER.error(f"       \u2717 File not found: {file!s}")
                         return_value = False
                     else:
-                        LOGGER.error(f"       \u2713 File found: {file!s}")
+                        LOGGER.info(f"       \u2713 File found: {file!s}")
 
             # TODO - other validation? required packages in requirement/pyproject.toml
 


### PR DESCRIPTION
This PR:

* Adds the `populate_manifest` and `update_manifests` functions to the `data` module
* Updates the command line tool to add the `manifests` subcommand that creates and updates file entries in manifests.
* Reworks the `check_data_directory` function to give prettier and terser reports on manifest file validation.
* Updates the `globus` module so it doesn't track `MANIFEST.yaml` files

Closes #2
